### PR TITLE
Pattern of story point label become configurable

### DIFF
--- a/src/css/options.css
+++ b/src/css/options.css
@@ -1,3 +1,7 @@
 body {
-  margin: 8px
+  margin: 8px;
+}
+
+#status {
+  white-space: pre;
 }

--- a/src/css/options.css
+++ b/src/css/options.css
@@ -1,0 +1,3 @@
+body {
+  margin: 8px
+}

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
+      <link href="/css/options.css" rel="stylesheet">
     </head>
     <body>
         <div id="labelPatternDiv">

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+    <head>
+    </head>
+    <body>
+        <div id="labelPatternDiv">
+            <label for="labelPattern">Pattern of story point labels(regular expression)</label>
+            <input type="text", id="labelPattern", name="labelPattern">
+        </div>
+        <div id="statusDiv"></div>
+    </body>
+    <script src="/js/options.js"></script>
+</html>
+

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -1,5 +1,12 @@
 const save_options = () => {
   const labelPattern = document.getElementById('labelPattern').value;
+  const validation_result = validate_pattern(labelPattern);
+  if(!validation_result.passed) {
+    const status = document.getElementById('statusDiv');
+    status.textContent = validation_result.messages.join('\r\n');
+    return;
+  }
+
   chrome.storage.sync.set(
     { labelPattern },
     () => {
@@ -9,7 +16,8 @@ const save_options = () => {
       setTimeout(function() {
         status.textContent = '';
       }, 750);
-  });
+    }
+  );
 }
 
 const restore_options = () => {
@@ -19,6 +27,16 @@ const restore_options = () => {
       document.getElementById('labelPattern').value = items.labelPattern;
     }
   );
+}
+
+const validate_pattern = (pattern) => {
+  const result = { messages: [] };
+  const number_pattern = pattern.match(/\(\\d\+\)/);
+  if(!number_pattern) {
+    result.messages.push('Pattern must contains "(\\d+)".')
+  }
+  result.passed = result.messages.length === 0 ? true : false;
+  return result;
 }
 
 document.addEventListener('DOMContentLoaded', restore_options);

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -1,0 +1,25 @@
+const save_options = () => {
+  const labelPattern = document.getElementById('labelPattern').value;
+  chrome.storage.sync.set(
+    { labelPattern },
+    () => {
+      // Update status to let user know options were saved.
+      const status = document.getElementById('statusDiv');
+      status.textContent = 'Options saved.';
+      setTimeout(function() {
+        status.textContent = '';
+      }, 750);
+  });
+}
+
+const restore_options = () => {
+  chrome.storage.sync.get(
+    { labelPattern: '\d+(pt|pts)' }, 
+    (items) => {
+      document.getElementById('labelPattern').value = items.labelPattern;
+    }
+  );
+}
+
+document.addEventListener('DOMContentLoaded', restore_options);
+document.getElementById('labelPattern').addEventListener('input', save_options);

--- a/src/js/storyPoint.js
+++ b/src/js/storyPoint.js
@@ -29,7 +29,8 @@ const findOrCreateStoryPointConter = (column) => {
 
 const setStoryPoint = (column, points) => {
   const storyPointConter = findOrCreateStoryPointConter(column);
-  storyPointConter.textContent = points + 'pt'
+  const suffix = points === 1 ? 'pt' : 'pts';
+  storyPointConter.textContent = points + suffix;
 }
 
 const calculateStoryPoints = (column, pattern) => {
@@ -81,8 +82,19 @@ const initialize = (pattern) => {
   setAutoCalculation(pattern);
 }
 
+const labelPattern = async () => {
+  return new Promise((resolve) => {
+    chrome.storage.sync.get(
+      { labelPattern: '(\d+)pt(s|)' },
+      (items) => {
+        resolve(new RegExp(items.labelPattern))
+      }
+    )
+  });
+}
+
 (async () => {
-  const pattern = /(\d+)pt/;
+  const pattern = await labelPattern();
   const projectColumns = toArray(getProjectColumns());
   await Promise.all(
     projectColumns.map(column => detectFinishToLoadCards(column))

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -20,5 +20,12 @@
         "js/storyPoint.js"
       ]
     }
-  ]
+  ],
+  "permissions": [
+    "storage"
+  ],
+  "options_ui": {
+    "page": "html/options.html",
+    "open_in_tab": false
+  }
 }


### PR DESCRIPTION
fixes #9 
Users can be changed the pattern of labels to be matches with labels used in their projects.

## Changes

- Add options page
- Use the pattern loaded from [`chrome.storage`](https://developer.chrome.com/extensions/storage) for story point calculation
    - default label pattern: `(\d+)pt(s|)`
- Add validator for label patterns
    - Define 1 rule -- Patterns must contains `(\d+)`